### PR TITLE
ProductとUserのAssociationを削除した

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -28,8 +28,6 @@ class ProductsController < ApplicationController
   # POST /products.json
   def create
     @product = Product.new(product_params)
-    @product.user_id = current_user.id
-
     respond_to do |format|
       if @product.save
         format.html { redirect_to @product, notice: 'Product was successfully created.' }
@@ -77,6 +75,6 @@ class ProductsController < ApplicationController
     end
 
     def correct_user
-      raise Forbidden, '権限がありません' unless @product.owned_by?(current_user)
+      raise Forbidden, '権限がありません' unless current_user.admin?
     end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -22,7 +22,6 @@ class Product < ApplicationRecord
   validates :url, presence: true, uniqueness: { case_sensitive: false }
   validates :desc, presence: true
 
-  belongs_to :user, optional: true
   belongs_to :category, optional: true
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  has_many :products
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -134,12 +134,10 @@
                         <%= fa_icon 'twitter' %>
                       <% end %>
                       <span style="font-size: 0.6em">
-                          <% if user_signed_in? %>
-                            <% if product.owned_by?(current_user) %>
+                          <% if current_user&.admin? %>
                               <%= link_to '編集', edit_product_path(product) %>
                             <span> </span>
                             <%= link_to '削除', product, method: :delete, data: {confirm: 'Are you sure?'} %>
-                            <% end %>
                           <% end %>
                         </span>
                       <br>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -23,12 +23,10 @@
               <p class="title is-5"><%= link_to @product.name, @product.url %>
                 <span><i class="fas fa-external-link-alt is-size-6"></i></span>
                 <span style="font-size: 0.4em">
-                <% if user_signed_in? %>
-                  <% if @product.owned_by?(current_user) %>
+                <% if current_user&.admin? %>
                     <%= link_to '編集', edit_product_path(@product) %>
                       <span> </span>
                       <%= link_to '削除', @product, method: :delete, data: {confirm: 'Are you sure?'} %>
-                  <% end %>
                 <% end %>
               </span>
               </p>

--- a/db/migrate/20180730142901_remove_user_from_product.rb
+++ b/db/migrate/20180730142901_remove_user_from_product.rb
@@ -1,0 +1,5 @@
+class RemoveUserFromProduct < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :products, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_12_115600) do
+ActiveRecord::Schema.define(version: 2018_07_30_142901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,12 +49,10 @@ ActiveRecord::Schema.define(version: 2018_07_12_115600) do
     t.string "thumbnail"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
     t.integer "likes_count", default: 0, null: false
     t.integer "status", default: 0, null: false
     t.bigint "category_id"
     t.index ["category_id"], name: "index_products_on_category_id"
-    t.index ["user_id"], name: "index_products_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -82,5 +80,4 @@ ActiveRecord::Schema.define(version: 2018_07_12_115600) do
   add_foreign_key "likes", "products"
   add_foreign_key "likes", "users"
   add_foreign_key "products", "categories"
-  add_foreign_key "products", "users"
 end

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProductsController, type: :controller do
-  let(:product) { create(:product) }
+  let!(:product) { create(:product) }
   let(:guest) { create(:user) }
   let(:admin) { create(:user, :admin) }
   let(:valid_attributes) {
@@ -42,23 +42,16 @@ RSpec.describe ProductsController, type: :controller do
 
 
   describe 'GET #edit' do
-    let(:product) { create(:product) }
-    context 'when owner logs in' do
+    context 'when admin logs in' do
       it 'returns a success response' do
-        sign_in product.user
+        sign_in admin
         get :edit, params: { id: product.to_param }
         expect(response).to be_successful
       end
     end
-    context 'when not owner logs in' do
+    context 'when not admin logs in' do
       it 'returns a failure response' do
         sign_in guest
-        get :edit, params: { id: product.to_param }
-        expect(response).not_to be_successful
-      end
-    end
-    context 'When anyone not logged in' do
-      it 'returns a failure response' do
         get :edit, params: { id: product.to_param }
         expect(response).not_to be_successful
       end
@@ -67,7 +60,22 @@ RSpec.describe ProductsController, type: :controller do
 
 
   describe "POST #create" do
-    context 'when user logs in' do
+    context 'when admin logs in' do
+      it "creates a new Product" do
+        sign_in admin
+        expect {
+          post :create, params: { product: valid_attributes }
+        }.to change(Product, :count).by(1)
+      end
+
+      it "redirects to the created category" do
+        sign_in admin
+        post :create, params: { product: valid_attributes }
+        expect(response).to redirect_to(Product.last)
+      end
+    end
+
+    context 'when guest logs in' do
       it "creates a new Product" do
         sign_in guest
         expect {
@@ -81,8 +89,7 @@ RSpec.describe ProductsController, type: :controller do
         expect(response).to redirect_to(Product.last)
       end
     end
-
-    context 'when anyone not logged in' do
+    context 'when anyone logged in' do
       it "returns a failure response" do
         post :create, params: { product: valid_attributes }
         expect(response).not_to be_successful
@@ -91,20 +98,20 @@ RSpec.describe ProductsController, type: :controller do
   end
 
   describe 'PUT #update' do
-    context 'when owner logs in' do
+    context 'when admin logs in' do
       let(:new_attributes) {
         { name: 'test update' }
       }
 
       it 'updates the requested product' do
-        sign_in product.user
+        sign_in admin
         put :update, params: { id: product.to_param, product: new_attributes }
         product.reload
         expect(product.name).to eq new_attributes[:name]
       end
 
       it "redirects to the product" do
-        sign_in product.user
+        sign_in admin
         put :update, params: { id: product.to_param, product: valid_attributes }
         expect(response).to redirect_to(product)
       end
@@ -125,16 +132,16 @@ RSpec.describe ProductsController, type: :controller do
   end
 
   describe "DELETE #destroy" do
-    context 'when owner logs in' do
+    context 'when admin logs in' do
       it "destroys the requested category" do
-        sign_in product.user
+        sign_in admin
         expect {
           delete :destroy, params: { id: product.to_param }
         }.to change(Product, :count).by(-1)
       end
 
       it "redirects to the categories list" do
-        sign_in product.user
+        sign_in admin
         delete :destroy, params: { id: product.to_param }
         expect(response).to redirect_to(products_url)
       end

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -7,6 +7,5 @@ FactoryBot.define do
     desc Faker::Lorem.sentence
     image Faker::App.name
     thumbnail Faker::App.name
-    user
   end
 end

--- a/spec/helpers/ownable_module_spec.rb
+++ b/spec/helpers/ownable_module_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe Ownable do
-  let(:product) { create :product }
+  let(:like) { create :like }
   describe '#owned_by?' do
     it 'should be true when product is owned by user' do
-      expect(product.owned_by?(product.user)).to be true
+      expect(like.owned_by?(like.user)).to be true
     end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Product, type: :model do
   describe '#liked?' do
     let!(:product) { create(:product) }
     let(:like) { create(:like) }
+    let(:user) { create(:user) }
 
     context 'when product is liked by user' do
       it 'should be true' do
@@ -80,7 +81,7 @@ RSpec.describe Product, type: :model do
     end
     context 'when user do NOT like a product' do
       it 'should be false' do
-        expect(product.liked?(product.user)).to be false
+        expect(product.liked?(user)).to be false
       end
     end
   end


### PR DESCRIPTION
@shoheis 
UserとProductが belong_toでアソシエーションしているのですが、こちらを削除しました。

サービスの設計でUserがプロダクトを投稿するというよりは、管理者がプロダクトを登録して、Userは閲覧するだけに変更したいからです。

また、Productの削除や更新や追加はadmin権限があるユーザのみ行えるようにいたしました。